### PR TITLE
9 add coastal analysis tab

### DIFF
--- a/HMS.Dashboard/app.R
+++ b/HMS.Dashboard/app.R
@@ -23,7 +23,7 @@ source("nmfs_cols.R")
 addResourcePath("tmpuser", getwd())
 
 # Load most recent data file (manually taken from Seafood Dashboard)
-load('hms_data_munge_10_28_25.RData')
+load('hms_data_munge_10_29_25.RData')
 
 
 # filter out confidential data (no data contained therein)


### PR DESCRIPTION
Coastal analysis tab provides simple value, volume, and price plots of trade, landings, and pp faceted out by coast. This might beg an option to facet by species (or top species), which could be added later. 

This pull includes a change to tooltips that may be more efficient, and should be worked in to other tooltips in this dashboard.