### PR TITLE
32 fix species search button and region button

### DIFF
--- a/HMS.Dashboard/app.R
+++ b/HMS.Dashboard/app.R
@@ -3616,7 +3616,7 @@ server <- function(input, output, session) {
   # define search bar terms
   output$filter_0 <- renderUI({
     species_list <- c('', sort(c(categorization_matrix %>%
-                                   filter_coast(coast_selection()) %>%
+                                   # filter_coast(coast_selection()) %>%
                                    select(SPECIES_NAME) %>%
                                    distinct() %>%
                                    filter(!is.na(SPECIES_NAME)) %>%
@@ -3738,36 +3738,35 @@ server <- function(input, output, session) {
       select(COAST) %>%
       distinct() %>%
       pull()
-    
-    if (!(is.null(input$species_cat))) {
-      coast_options <- categorization_matrix %>%
-        filter_species(input$species_cat) %>%
-        filter(!is.na(COAST)) %>%
-        select(COAST) %>%
-        distinct() %>%
-        pull()
-    }
-    
-    if (!(is.null(input$species_grp))) {
-      coast_options <- categorization_matrix %>%
-        filter_species(input$species_cat) %>%
-        filter_species(input$species_grp) %>%
-        filter(!is.na(COAST)) %>%
-        select(COAST) %>%
-        distinct() %>%
-        pull()
-    }
-    
-    if (!(is.null(input$species_name))) {
-      coast_options <- categorization_matrix %>%
-        filter_species(input$species_cat) %>%
-        filter_species(input$species_grp) %>%
-        filter_species(input$species_name) %>%
-        filter(!is.na(COAST)) %>%
-        select(COAST) %>%
-        distinct() %>%
-        pull()
-    }
+    # if (!(is.null(input$species_cat))) {
+    #   coast_options <- categorization_matrix %>%
+    #     filter_species(input$species_cat) %>%
+    #     filter(!is.na(COAST)) %>%
+    #     select(COAST) %>%
+    #     distinct() %>%
+    #     pull()
+    # }
+    # 
+    # if (!(is.null(input$species_grp))) {
+    #   coast_options <- categorization_matrix %>%
+    #     filter_species(input$species_cat) %>%
+    #     filter_species(input$species_grp) %>%
+    #     filter(!is.na(COAST)) %>%
+    #     select(COAST) %>%
+    #     distinct() %>%
+    #     pull()
+    # }
+    # 
+    # if (!(is.null(input$species_name))) {
+    #   coast_options <- categorization_matrix %>%
+    #     filter_species(input$species_cat) %>%
+    #     filter_species(input$species_grp) %>%
+    #     filter_species(input$species_name) %>%
+    #     filter(!is.na(COAST)) %>%
+    #     select(COAST) %>%
+    #     distinct() %>%
+    #     pull()
+    # }
     
     coast_list <- factor(coast_options, levels = coast_order, ordered = T)
     ordered_coasts <- as.vector(sort(coast_list))

--- a/HMS.Dashboard/app.R
+++ b/HMS.Dashboard/app.R
@@ -3616,6 +3616,7 @@ server <- function(input, output, session) {
   # define search bar terms
   output$filter_0 <- renderUI({
     species_list <- c('', sort(c(categorization_matrix %>%
+                                   # see note in output$filter_coast
                                    # filter_coast(coast_selection()) %>%
                                    select(SPECIES_NAME) %>%
                                    distinct() %>%
@@ -3738,6 +3739,12 @@ server <- function(input, output, session) {
       select(COAST) %>%
       distinct() %>%
       pull()
+    # Below would filter coasts available based on species selected prior.
+    # This is commented out because the filters for coast and species selection
+      # are parallel rather than hierarchical. That means filtering for one
+      # affects the other, which affects the other, and thus a loop is made
+    # If put back, searching for a species would overwrite coast, and vice versa
+    
     # if (!(is.null(input$species_cat))) {
     #   coast_options <- categorization_matrix %>%
     #     filter_species(input$species_cat) %>%


### PR DESCRIPTION
The fix is simple, however function has changed.

Previously, selection filters were designed such that selecting a certain species would change the coasts available for filtering (i.e., coasts for which that species is landed, processed, or traded are available for filtering) and vice versa. This relationship would falter if the species was searched for rather than progressively selected in the filtering hierarchy. In that case, searching for a species would overwrite any previously selected coast, and selecting a coast would overwrite (revert) any searched species. 

The intention for the former construction lied in communicating to the user what data was available to them based on their selections. This is consistent with how selecting an ecological category dictates what species categories are available, for instance. However, having two filters operate in parallel (where they depend upon the other and do not engage hierarchically), at present, seems impossible to reconcile all desired functions of the dashboard. In other words, one function must be selected: (1) coasts do not update based on selected or searched species, and available species do not change based on selected coasts, or (2) searching for a species and selecting a coast simultaneously cannot happen. 

The result of this pull and resolution of this issue lies in the former option. Users now will no longer see prior selections overwritten based on other selections in favor of leaving coasts and species available for selection for which there may be no data. This downside is likely uncommon to occur, and in fact raises the value of the 'unfilter buttons' for trade, landings, and processing. In the event a user searches for a species and selects a coast for which that species is not available, the unfilter buttons will be made available, communicating to the user that this species does not exist for that coast (data-type dependent). If the user selects the button and nothing changes, the dashboard indirectly communicates to the user that this coast has no data for any level of this species in the hierarchy. In this way, all desired communication functions of the dashboard are retained, some have simply changed in their delivery. 

A future resolution could involve pop-ups that communicate directly the lack of data for the given species/coast combination, or some method that presents species and coasts available for selection based on prior choices without overwriting filters.